### PR TITLE
Added logout to usermod take effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ echo \
 sudo apt update
 sudo apt install docker-ce docker-ce-cli containerd.io
 sudo usermod -aG docker <user>
+logout
+su - <user>
+docker --version
 
 # Install docker-compose
 sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose


### PR DESCRIPTION
After installing Docker, user needs to logout and login to be into the `docker` group.